### PR TITLE
Build aggregation automatically after other jobs complete

### DIFF
--- a/orbit-aggregation/OrbitAggregation.jenkinsfile
+++ b/orbit-aggregation/OrbitAggregation.jenkinsfile
@@ -7,6 +7,22 @@ pipeline {
     skipDefaultCheckout true
   }
 
+  properties(
+    [pipelineTriggers(
+      [upstream(
+          upstreamProjects: 'orbit-simrel-maven-osgi',
+          threshold: hudson.model.Result.SUCCESS
+      ),
+      upstream(
+          upstreamProjects: 'orbit-simrel-maven-bnd',
+          threshold: hudson.model.Result.SUCCESS
+      ),
+      upstream(
+          upstreamProjects: 'orbit-recipes',
+          threshold: hudson.model.Result.SUCCESS
+      )]
+    )]
+  )
   tools {
     maven 'apache-maven-latest'
     jdk 'temurin-jdk17-latest'


### PR DESCRIPTION
@merks I am not sure if this syntax is correct, not sure how to test without merging. I created this because at the moment the https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/index.html is from July 18th, but https://download.eclipse.org/tools/orbit/simrel/maven-bnd/nightly/index.html is from July 21st