### PR TITLE
Add Apache PDFBox 2

### DIFF
--- a/report/maven-osgi/platform/original.target
+++ b/report/maven-osgi/platform/original.target
@@ -704,6 +704,34 @@
 			  </dependency>
 		  </dependencies>
 	  </location>
+	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Apache PDFBox" missingManifest="generate" type="Maven">
+		  <dependencies>
+			  <dependency>
+				  <groupId>org.apache.pdfbox</groupId>
+				  <artifactId>fontbox</artifactId>
+				  <version>2.0.35</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>org.apache.pdfbox</groupId>
+				  <artifactId>pdfbox</artifactId>
+				  <version>2.0.35</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>org.apache.pdfbox</groupId>
+				  <artifactId>preflight</artifactId>
+				  <version>2.0.35</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>org.apache.pdfbox</groupId>
+				  <artifactId>xmpbox</artifactId>
+				  <version>2.0.35</version>
+				  <type>jar</type>
+			  </dependency>
+		  </dependencies>
+	  </location>
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="JUnit 5" missingManifest="error" type="Maven">
 		  <dependencies>
 			  <dependency>


### PR DESCRIPTION
I want to add this on behalf of @eclipse-chemclipse as I think it might not be the only project interested in it. Apache PDFBox was part of Orbit in the past. As it is large in file size and the Eclipse Foundation download servers are slow, it might make sense to mirror it and remove it from integration builds. Otherwise there is nothing special to it. It works out of the box with @eclipse-m2e. 

Although I don't understand how to trigger the automated process in this repository to add it to the reports and the other target platform so need guidance there.