### PR TITLE
Add capabilities to Skija libraries to enforce loading fragment

### DIFF
--- a/maven-bnd/tp/MavenBND.target
+++ b/maven-bnd/tp/MavenBND.target
@@ -235,7 +235,7 @@ Export-Package:         *;version="${version}";-noimport:=true
 <!-- _______________________________________________________ io.github.humbleui.skija-shared _________________________________________________________________________________________________-->
 
     <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
-      <feature id="org.eclipse.orbit.maven.io.github.humbleui.skija-shared" label="Orbit Maven BND io.github.humbleui.skija-shared" provider-name="Eclipse Orbit" version="4.40.0.v20260519-1000">
+      <feature id="org.eclipse.orbit.maven.io.github.humbleui.skija-shared" label="Orbit Maven BND io.github.humbleui.skija-shared" provider-name="Eclipse Orbit" version="4.40.0.v20260519-1800">
         <description>This feature's dependencies are pulled directly from Maven central and wrapped via BND recipe as OSGi artifacts.</description>
         <copyright>
 Copyright (c) 2026 Eclipse contributors and others.
@@ -263,8 +263,9 @@ SPDX-License-Identifier: EPL-2.0
 Bundle-Name:            Bundle ${mvnGroupId} : ${mvnArtifactId}
 version:                ${versionmask;===;${version_cleanup;${mvnVersion}}}
 Bundle-SymbolicName:    ${mvnGroupId}.${mvnArtifactId}
-Bundle-Version:         ${version}.v20260519-1000
+Bundle-Version:         ${version}.v20260519-1800
 Eclipse-Wrapped-Bundle: ${mvnGroupId}:${mvnArtifactId}:${mvnVersion}
+Require-Capability:     ${mvnGroupId}.skija;filter:="(library=native)"
 Import-Package:         *
 Export-Package:         *;version="${version}";-noimport:=true
 -noextraheaders:        true

--- a/maven-sign/tp/MavenSign.target
+++ b/maven-sign/tp/MavenSign.target
@@ -84,7 +84,7 @@ Bundle-Version:         ${version}.v20251001-0800
 <!-- _______________________________________________________ io.github.humbleui.skija-native _________________________________________________________________________________________________-->
 
     <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
-      <feature id="org.eclipse.orbit.maven.io.github.humbleui.skija-native" label="Orbit Maven BND io.github.humbleui.skija-native" provider-name="Eclipse Orbit" version="4.40.0.v20260519-1000">
+      <feature id="org.eclipse.orbit.maven.io.github.humbleui.skija-native" label="Orbit Maven BND io.github.humbleui.skija-native" provider-name="Eclipse Orbit" version="4.40.0.v20260519-1800">
         <description>This feature's dependencies are pulled directly from Maven central and wrapped via BND recipe as OSGi artifacts.</description>
         <copyright>
 Copyright (c) 2026 Eclipse contributors and others.
@@ -137,10 +137,11 @@ SPDX-License-Identifier: EPL-2.0
 version:                ${versionmask;===;${version_cleanup;${mvnVersion}}}
 # Bundles that match this pattern will be updated to use this qualifier.
 # bundle-pattern:       io.github.humbleui.skija-(linux|macos|windows)-(x64|arm64)(.source)?
-Bundle-Version:         ${version}.v20260519-1000
+Bundle-Version:         ${version}.v20260519-1800
 Bundle-Name:            Bundle ${mvnGroupId} : ${mvnArtifactId}
 Bundle-SymbolicName:    ${mvnGroupId}.${mvnArtifactId}
 Eclipse-Wrapped-Bundle: ${mvnGroupId}:${mvnArtifactId}:${mvnVersion}
+Provide-Capability:     ${mvnGroupId}.skija;library="native";version:Version="1.0"
 Fragment-Host: io.github.humbleui.skija-shared;bundle-version="${range;[==,+);${version}}"
 os:                     ${replacestring;${replacestring;${replacestring;${mvnArtifactId};.*-macos-.*;macosx};.*-linux-.*;linux};.*-windows-.*;win32}
 arch:                   ${replacestring;${replacestring;${mvnArtifactId};.*-arm64.*;aarch64};.*-x64.*;x86_64}


### PR DESCRIPTION
Skija libraries are split into the skija-shared host and the actual native libraries for adopting Skia wrapped into fragments. Those fragments currently need to be explicitly pulled into an OSGi environment to make use of Skija, as the skija-shared library effectly depends on the presence of either of the fragments with the native libraries.

This change adds OSGi capabilities to the Skija libraries, such that the skija-shared host always requires one of the fragments to be present. This leads to the fitting fragment for the current platform automatically being pulled into a launch if available.

I am not sure how such a capability should be defined best, and I am also not sure if such a dependency between fragment and host may in any way be problematic. I locally patched the bundles/fragments in my bundle pool with these changes and the SWT Skia prototype with its tests (see https://github.com/eclipse-platform/eclipse.platform.swt/pull/3231) worked fine then. See also https://github.com/eclipse-platform/eclipse.platform.swt/pull/3231#issuecomment-4489286145 for some context of this change as probably required for the SWT Skia adoption.